### PR TITLE
Add stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Adding stat module
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -117,3 +117,20 @@ pyswtools auto-export PATH/TO/DIR MODE
 ```
 
 With `Mode` being `AUTO`, `DXF` or `STL`. It will create directory with the extension used  and the corresponding files in it.
+
+### Stat
+This tool help you get stat on an assembly. It can gives you recursive information about the mass of each component of an assembly.
+
+#### How to use
+
+```
+pyswtools stat PATH/TO/ASSEMBLY OPTIONS
+```
+
+You can select the display mode:
+- `--tree`: (default) It will follow the structure from the assembly file
+- `--list`: It will output to a single list
+
+You can select the sort:
+- `--mass`: (default) sort with a decreasing mass
+- `--name`: sort with alphabetical order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyswtools"
-version = "0.5.0"
+version = "0.6.0"
 description = "Set of tools to improve Solidworks usage"
 authors = ["ldevillez <louis.devillez@gmail.com>"]
 license = "GNU General Public License"

--- a/pyswtools/main.py
+++ b/pyswtools/main.py
@@ -8,9 +8,10 @@ from .config import config
 from .ready_dxf.main import ready_dxf
 from .copy_full_assembly.main import copy_full_assembly
 from .auto_exporter.main import auto_export
+from .stat.main import stat
 
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Devillez Louis"
 __maintainer__ = "Deville Louis"
 __email__ = "louis.devillez@gmail.com"
@@ -29,6 +30,7 @@ cli.add_command(config)
 cli.add_command(ready_dxf)
 cli.add_command(copy_full_assembly)
 cli.add_command(auto_export)
+cli.add_command(stat)
 
 if __name__ == "__main__":
     cli()

--- a/pyswtools/stat/main.py
+++ b/pyswtools/stat/main.py
@@ -2,14 +2,7 @@
 Give stat from an assembly
 """
 
-import click
-
-"""
-Auto export of solidworks files to other extensions
-"""
-
 import os
-import math
 import click
 
 # pylint: disable=relative-beyond-top-level
@@ -25,42 +18,74 @@ if check_system():
     VT_Views = win32com.client.VARIANT(pythoncom.VT_VARIANT, Views)
     VT_BYREF = win32com.client.VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, -1)
 
-#TODO define type_sort and type_output as dataclass
+# TODO define type_sort and type_output as dataclass
+
 
 def sort_key_struct(struct, type_sort):
+    """
+    Sort a dict struct following a given sort
+    """
     if type_sort == "name":
-        return sorted(struct.keys(),key=str.lower)
+        return sorted(struct.keys(), key=str.lower)
     if type_sort == "mass":
-        return sorted(struct.keys(), key=lambda i: struct[i]["mass"]*struct[i]["number"],reverse=True )
+        return sorted(
+            struct.keys(),
+            key=lambda i: struct[i]["mass"] * struct[i]["number"],
+            reverse=True,
+        )
 
     return struct.keys()
 
+
 def display_tree(tree_struct_mass, type_sort="name", indent=0):
+    """
+    Display a tree struct recursively
+    """
     for elem in sort_key_struct(tree_struct_mass, type_sort):
-        click.echo(f"{'  ' * indent + '- ' + elem :<50} : {tree_struct_mass[elem]['mass'] * tree_struct_mass[elem]['number']:5.3f} ({tree_struct_mass[elem]['number']:3d} x {tree_struct_mass[elem]['mass']:6.4f})")
+        click.echo(
+            f"{'  ' * indent + '- ' + elem :<50} : {tree_struct_mass[elem]['mass'] * tree_struct_mass[elem]['number']:5.3f} ({tree_struct_mass[elem]['number']:3d} x {tree_struct_mass[elem]['mass']:6.4f})"
+        )
         if len(tree_struct_mass[elem]["children"]) > 0:
-            display_tree(tree_struct_mass[elem]["children"],type_sort, indent+1)
+            display_tree(tree_struct_mass[elem]["children"], type_sort, indent + 1)
+
 
 def display_list(list_struct, type_sort="name"):
+    """
+    Display a list struct
+    """
     for elem in sort_key_struct(list_struct, type_sort):
-        click.echo(f"{'- ' + elem :<50} : {list_struct[elem]['mass'] * list_struct[elem]['number']:5.3f} ({list_struct[elem]['number']:3d} x {list_struct[elem]['mass']:6.4f})")
+        click.echo(
+            f"{'- ' + elem :<50} : {list_struct[elem]['mass'] * list_struct[elem]['number']:5.3f} ({list_struct[elem]['number']:3d} x {list_struct[elem]['mass']:6.4f})"
+        )
+
 
 def get_clean_name(sw_comp):
+    """
+    Get the cleaned name from a component
+    """
     return sw_comp.Name2.rpartition("-")[0].rpartition("/")[-1]
 
+
 def complete_info_on_list(sw_comp_children, dict_of_comp):
+    """
+    Get all the info from a list of component
+    """
     children = {}
     for sw_child in sw_comp_children:
         sw_child_name = get_clean_name(sw_child)
         child = complete_info_assembly(sw_child, dict_of_comp)
-        if sw_child_name not in children.keys():
+        if sw_child_name not in children:
             children[sw_child_name] = child
         else:
             children[sw_child_name]["number"] += 1
 
     return children
 
+
 def complete_info_assembly(sw_comp, dict_of_comp):
+    """
+    Get all the information from an assembly
+    """
     sw_comp_name = get_clean_name(sw_comp)
 
     if sw_comp_name in dict_of_comp:
@@ -69,20 +94,17 @@ def complete_info_assembly(sw_comp, dict_of_comp):
         sw_comp_doc_ext = sw_comp.GetModelDoc2.Extension
         sw_mass = sw_comp_doc_ext.CreateMassProperty2.Mass
 
-        dict_of_comp[sw_comp_name] = {
-            "number": 1,
-            "mass": sw_mass
-        }
-    
+        dict_of_comp[sw_comp_name] = {"number": 1, "mass": sw_mass}
+
     sw_comp_children = sw_comp.GetChildren
     children = complete_info_on_list(sw_comp_children, dict_of_comp)
-
 
     return {
         "mass": dict_of_comp[sw_comp_name]["mass"],
         "number": 1,
         "children": children,
     }
+
 
 @click.command()
 @click.help_option("-h", "--help")
@@ -91,12 +113,12 @@ def complete_info_assembly(sw_comp, dict_of_comp):
     type=click.Path(
         exists=True,
         dir_okay=False,
-        ),
+    ),
 )
-@click.option('--tree', 'type_output', flag_value='tree', default=True)
-@click.option('--list', 'type_output', flag_value='list')
-@click.option('--mass', 'type_sort', flag_value='mass', default=True)
-@click.option('--name', 'type_sort', flag_value='name')
+@click.option("--tree", "type_output", flag_value="tree", default=True)
+@click.option("--list", "type_output", flag_value="list")
+@click.option("--mass", "type_sort", flag_value="mass", default=True)
+@click.option("--name", "type_sort", flag_value="name")
 def stat(input_path, type_output, type_sort) -> None:
     """
     Display stat about an assembly
@@ -109,7 +131,7 @@ def stat(input_path, type_output, type_sort) -> None:
         click.echo(f"{input_path} is not an assembly file")
         return
 
-    path_directory, filename = os.path.split(input_path)
+    _, filename = os.path.split(input_path)
 
     conf = get_config()
 
@@ -123,12 +145,17 @@ def stat(input_path, type_output, type_sort) -> None:
     # Activate it
     sw_app.ActivateDoc3(filename, True, 2, VT_BYREF)
 
+    # Get list of components
     sw_comps = sw_doc.GetComponents(True)
+
+    # Empty struct to fill
     dict_of_comp = {}
-    children = complete_info_on_list(sw_comps, dict_of_comp)
+
+    # Get all the infos
+    tree_of_infos = complete_info_on_list(sw_comps, dict_of_comp)
 
     if type_output == "tree":
-        display_tree(children, type_sort)
+        display_tree(tree_of_infos, type_sort)
     elif type_output == "list":
         display_list(dict_of_comp, type_sort)
     else:

--- a/pyswtools/stat/main.py
+++ b/pyswtools/stat/main.py
@@ -3,11 +3,27 @@ Give stat from an assembly
 """
 
 import os
+from enum import Enum
 import click
 
 # pylint: disable=relative-beyond-top-level
 from ..utils import check_system, check_system_verbose
 from ..config import get_config
+
+
+class TypeOutput(Enum):
+    """Class represeting an output type"""
+
+    TREE = 1
+    LIST = 2
+
+
+class TypeSort(Enum):
+    """Class represeting an output type"""
+
+    MASS = 1
+    NAME = 2
+
 
 if check_system():
     # pylint: disable=import-error
@@ -18,16 +34,14 @@ if check_system():
     VT_Views = win32com.client.VARIANT(pythoncom.VT_VARIANT, Views)
     VT_BYREF = win32com.client.VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, -1)
 
-# TODO define type_sort and type_output as dataclass
 
-
-def sort_key_struct(struct, type_sort):
+def sort_key_struct(struct: dict, type_sort: TypeSort = TypeSort.MASS) -> list:
     """
     Sort a dict struct following a given sort
     """
-    if type_sort == "name":
+    if type_sort == TypeSort.NAME:
         return sorted(struct.keys(), key=str.lower)
-    if type_sort == "mass":
+    if type_sort == TypeSort.MASS:
         return sorted(
             struct.keys(),
             key=lambda i: struct[i]["mass"] * struct[i]["number"],
@@ -37,7 +51,9 @@ def sort_key_struct(struct, type_sort):
     return struct.keys()
 
 
-def display_tree(tree_struct_mass, type_sort="name", indent=0):
+def display_tree(
+    tree_struct_mass: dict, type_sort: TypeSort = TypeSort.NAME, indent: int = 0
+) -> None:
     """
     Display a tree struct recursively
     """
@@ -49,7 +65,7 @@ def display_tree(tree_struct_mass, type_sort="name", indent=0):
             display_tree(tree_struct_mass[elem]["children"], type_sort, indent + 1)
 
 
-def display_list(list_struct, type_sort="name"):
+def display_list(list_struct: dict, type_sort: TypeSort = TypeSort.NAME) -> None:
     """
     Display a list struct
     """
@@ -59,21 +75,26 @@ def display_list(list_struct, type_sort="name"):
         )
 
 
-def get_clean_name(sw_comp):
+def get_clean_name(sw_comp) -> str:
     """
-    Get the cleaned name from a component
+    Get the cleaned name from a component. remove the number from the component
     """
     return sw_comp.Name2.rpartition("-")[0].rpartition("/")[-1]
 
 
-def complete_info_on_list(sw_comp_children, dict_of_comp):
+def complete_info_on_list(sw_comp_children, dict_of_comp: dict) -> dict:
     """
     Get all the info from a list of component
     """
     children = {}
     for sw_child in sw_comp_children:
+        # Get the name
         sw_child_name = get_clean_name(sw_child)
+
+        # Get the info fo the assembly
         child = complete_info_assembly(sw_child, dict_of_comp)
+
+        # If the child is already here, only increase the number
         if sw_child_name not in children:
             children[sw_child_name] = child
         else:
@@ -82,23 +103,30 @@ def complete_info_on_list(sw_comp_children, dict_of_comp):
     return children
 
 
-def complete_info_assembly(sw_comp, dict_of_comp):
+def complete_info_assembly(sw_comp, dict_of_comp: dict) -> dict:
     """
     Get all the information from an assembly
     """
+
+    # Get name of component
     sw_comp_name = get_clean_name(sw_comp)
 
+    # If already there only increase the number
     if sw_comp_name in dict_of_comp:
         dict_of_comp[sw_comp_name]["number"] += 1
     else:
+        # Otherwise get the mass
         sw_comp_doc_ext = sw_comp.GetModelDoc2.Extension
         sw_mass = sw_comp_doc_ext.CreateMassProperty2.Mass
 
+        # Create an new entity in the general dict
         dict_of_comp[sw_comp_name] = {"number": 1, "mass": sw_mass}
 
+    # Get info about children
     sw_comp_children = sw_comp.GetChildren
     children = complete_info_on_list(sw_comp_children, dict_of_comp)
 
+    # Create the entry in the tree dict
     return {
         "mass": dict_of_comp[sw_comp_name]["mass"],
         "number": 1,
@@ -115,11 +143,11 @@ def complete_info_assembly(sw_comp, dict_of_comp):
         dir_okay=False,
     ),
 )
-@click.option("--tree", "type_output", flag_value="tree", default=True)
-@click.option("--list", "type_output", flag_value="list")
-@click.option("--mass", "type_sort", flag_value="mass", default=True)
-@click.option("--name", "type_sort", flag_value="name")
-def stat(input_path, type_output, type_sort) -> None:
+@click.option("--tree", "type_output", flag_value=TypeOutput.TREE, default=True)
+@click.option("--list", "type_output", flag_value=TypeOutput.LIST)
+@click.option("--mass", "type_sort", flag_value=TypeSort.MASS, default=True)
+@click.option("--name", "type_sort", flag_value=TypeSort.NAME)
+def stat(input_path: str, type_output: TypeOutput, type_sort: TypeSort) -> None:
     """
     Display stat about an assembly
     """
@@ -154,9 +182,9 @@ def stat(input_path, type_output, type_sort) -> None:
     # Get all the infos
     tree_of_infos = complete_info_on_list(sw_comps, dict_of_comp)
 
-    if type_output == "tree":
+    if type_output == TypeOutput.TREE:
         display_tree(tree_of_infos, type_sort)
-    elif type_output == "list":
+    elif type_output == TypeOutput.LIST:
         display_list(dict_of_comp, type_sort)
     else:
         pass

--- a/pyswtools/stat/main.py
+++ b/pyswtools/stat/main.py
@@ -1,0 +1,135 @@
+"""
+Give stat from an assembly
+"""
+
+import click
+
+"""
+Auto export of solidworks files to other extensions
+"""
+
+import os
+import math
+import click
+
+# pylint: disable=relative-beyond-top-level
+from ..utils import check_system, check_system_verbose
+from ..config import get_config
+
+if check_system():
+    # pylint: disable=import-error
+    import win32com.client
+    import pythoncom
+
+    Views = []
+    VT_Views = win32com.client.VARIANT(pythoncom.VT_VARIANT, Views)
+    VT_BYREF = win32com.client.VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, -1)
+
+#TODO define type_sort and type_output as dataclass
+
+def sort_key_struct(struct, type_sort):
+    if type_sort == "name":
+        return sorted(struct.keys(),key=str.lower)
+    if type_sort == "mass":
+        return sorted(struct.keys(), key=lambda i: struct[i]["mass"]*struct[i]["number"],reverse=True )
+
+    return struct.keys()
+
+def display_tree(tree_struct_mass, type_sort="name", indent=0):
+    for elem in sort_key_struct(tree_struct_mass, type_sort):
+        click.echo(f"{'  ' * indent + '- ' + elem :<50} : {tree_struct_mass[elem]['mass'] * tree_struct_mass[elem]['number']:5.3f} ({tree_struct_mass[elem]['number']:3d} x {tree_struct_mass[elem]['mass']:6.4f})")
+        if len(tree_struct_mass[elem]["children"]) > 0:
+            display_tree(tree_struct_mass[elem]["children"],type_sort, indent+1)
+
+def display_list(list_struct, type_sort="name"):
+    for elem in sort_key_struct(list_struct, type_sort):
+        click.echo(f"{'- ' + elem :<50} : {list_struct[elem]['mass'] * list_struct[elem]['number']:5.3f} ({list_struct[elem]['number']:3d} x {list_struct[elem]['mass']:6.4f})")
+
+def get_clean_name(sw_comp):
+    return sw_comp.Name2.rpartition("-")[0].rpartition("/")[-1]
+
+def complete_info_on_list(sw_comp_children, dict_of_comp):
+    children = {}
+    for sw_child in sw_comp_children:
+        sw_child_name = get_clean_name(sw_child)
+        child = complete_info_assembly(sw_child, dict_of_comp)
+        if sw_child_name not in children.keys():
+            children[sw_child_name] = child
+        else:
+            children[sw_child_name]["number"] += 1
+
+    return children
+
+def complete_info_assembly(sw_comp, dict_of_comp):
+    sw_comp_name = get_clean_name(sw_comp)
+
+    if sw_comp_name in dict_of_comp:
+        dict_of_comp[sw_comp_name]["number"] += 1
+    else:
+        sw_comp_doc_ext = sw_comp.GetModelDoc2.Extension
+        sw_mass = sw_comp_doc_ext.CreateMassProperty2.Mass
+
+        dict_of_comp[sw_comp_name] = {
+            "number": 1,
+            "mass": sw_mass
+        }
+    
+    sw_comp_children = sw_comp.GetChildren
+    children = complete_info_on_list(sw_comp_children, dict_of_comp)
+
+
+    return {
+        "mass": dict_of_comp[sw_comp_name]["mass"],
+        "number": 1,
+        "children": children,
+    }
+
+@click.command()
+@click.help_option("-h", "--help")
+@click.argument(
+    "input_path",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        ),
+)
+@click.option('--tree', 'type_output', flag_value='tree', default=True)
+@click.option('--list', 'type_output', flag_value='list')
+@click.option('--mass', 'type_sort', flag_value='mass', default=True)
+@click.option('--name', 'type_sort', flag_value='name')
+def stat(input_path, type_output, type_sort) -> None:
+    """
+    Display stat about an assembly
+    """
+    if not check_system_verbose():
+        return
+
+    if ".SLDASM" not in input_path or "~$" in input_path:
+        click.echo("Please select an assembly file (.SLDASM)")
+        click.echo(f"{input_path} is not an assembly file")
+        return
+
+    path_directory, filename = os.path.split(input_path)
+
+    conf = get_config()
+
+    sw_app = win32com.client.Dispatch(
+        f"SldWorks.Application.{(int(conf.sw_version)-2012+20)}"
+    )
+
+    # Open the assembly
+    sw_doc = sw_app.OpenDoc6(os.path.abspath(input_path), 2, 1, "", VT_BYREF, VT_BYREF)
+
+    # Activate it
+    sw_app.ActivateDoc3(filename, True, 2, VT_BYREF)
+
+    sw_comps = sw_doc.GetComponents(True)
+    dict_of_comp = {}
+    children = complete_info_on_list(sw_comps, dict_of_comp)
+
+    if type_output == "tree":
+        display_tree(children, type_sort)
+    elif type_output == "list":
+        display_list(dict_of_comp, type_sort)
+    else:
+        pass

--- a/pyswtools/utils.py
+++ b/pyswtools/utils.py
@@ -21,4 +21,3 @@ def check_system() -> bool:
     Check if the system is windows
     """
     return platform.system() == "Windows"
-

--- a/pyswtools/utils.py
+++ b/pyswtools/utils.py
@@ -21,3 +21,4 @@ def check_system() -> bool:
     Check if the system is windows
     """
     return platform.system() == "Windows"
+


### PR DESCRIPTION
# Description

Add a module to get the mass of each component from an assembly into a list or a tree (following the structure of the assembly)

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on command line on a multi-level assembly


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
