### PR TITLE
add density option to stat module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@
 ## [Unreleased]
 ### Added
 - Adding density info to stat module
+- Adding flag to stat module to get only elements with default density
 ### Changed
 - Improving the output of the state module with tabular like output
 - Updating the doc in the README for the stat module
+- Enum in click option for stat module
+- Changing option flag to choice for stat module
 ### Deprecated
 ### Removed
 ### Fixed
-- Enum in click option for stat module
-- Changing option flag to choice for stat module
 - Fix typo in maintainer name
-
+- Fix stat module for no volume part
 ### Security
 
 ## v0.6.0 - 2023/05/27

--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ This tool help you get stat on an assembly. It can gives you recursive informati
 pyswtools stat PATH/TO/ASSEMBLY OPTIONS
 ```
 
-You can select the display mode with `--type_output`:
+You can select the display mode with `--type-output`:
 - `tree`: (default) It will follow the structure from the assembly file
 - `list`: It will output to a single list
 
-You can select the sort mode with `--type_sort`:
+You can select the sort mode with `--type-sort`:
 - `mass`: (default) sort with a decreasing mass
 - `name`: sort with alphabetical order
+
+You can get only the elements with a default density (1000 Kg/m³) with the option `--only-default-density`. This option only works with a `type `list`


### PR DESCRIPTION
# Description
Add an option to only shows elements with default density.

Fixes #4 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Tested with and without the option on an assembly


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
