### PR TITLE
add conf in stat module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Adding clean module
 - Adding function to get directly sw_app, sw_doc
 - Adding bool function to test if file is assembly, part or temporary
+- Adding sorting option to mass of the part
+- Handling conf in the stat module
 ### Changed
 - Improving the output of the state module with tabular like output
 - Updating the doc in the README for the stat module

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ You can select the display mode with `--type-output`:
 - `list`: It will output to a single list
 
 You can select the sort mode with `--type-sort`:
-- `mass`: (default) sort with a decreasing mass
+- `mass`: (default) sort with a decreasing total mass
+- `mass-part`: sort with a decreasing part mass
 - `name`: sort with alphabetical order
 
 You can get only the elements with a default density (1000 Kg/m³) with the option `--only-default-density`. This option only works with a `type `list`


### PR DESCRIPTION
# Description

Previous version of the stat module did not consider the different configurations components.
Now different configuration with differents mass will each have their entry in the output.
If there is only one element, the configuration will be stripped (maybe it could be a column).
If the configuration have the same mass, they are fused.

Fixes #11 

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Tested on dummy assembly and personnal project

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
