### PR TITLE
FIX: conditions to avoid crash and avoid suppressed components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Deprecated
 ### Removed
 ### Fixed
+- Do not count suppressed components in the stat module
+- Add condition to avoid crash on non readable masss properties
 ### Security
 
 ## v0.7.0 - 2023/06/19

--- a/pyswtools/stat/main.py
+++ b/pyswtools/stat/main.py
@@ -240,6 +240,10 @@ def complete_info_on_list(sw_comp_children, dict_of_comp: dict) -> dict:
     """
     children = {}
     for sw_child in sw_comp_children:
+        # Do not treat suppressed comporents
+        if sw_child.GetSuppression2 == 0:
+            continue
+
         # Get the name
         sw_child_name = get_clean_name(sw_child)
 
@@ -267,15 +271,21 @@ def complete_info_assembly(sw_comp, dict_of_comp: dict) -> dict:
     if sw_comp_name in dict_of_comp:
         dict_of_comp[sw_comp_name]["number"] += 1
     else:
+        sw_mass = 0
+        sw_density = 0
         # set the configuration
         sw_comp_doc = sw_comp.GetModelDoc2
-        sw_comp_doc.ShowConfiguration2(sw_comp.ReferencedConfiguration)
-        # Get extension manager
-        sw_comp_doc_ext = sw_comp_doc.Extension
-        sw_mass_property = sw_comp_doc_ext.CreateMassProperty2
-        # Get mass and density
-        sw_mass = sw_mass_property.Mass if sw_mass_property is not None else 0
-        sw_density = sw_mass_property.Density if sw_mass_property is not None else 0
+        if sw_comp_doc is not None:
+            sw_comp_doc.ShowConfiguration2(sw_comp.ReferencedConfiguration)
+            # Get extension manager
+            sw_comp_doc_ext = sw_comp_doc.Extension
+            sw_mass_property = sw_comp_doc_ext.CreateMassProperty2
+
+            # Get mass and density
+            sw_mass = sw_mass_property.Mass if sw_mass_property is not None else 0
+            sw_density = sw_mass_property.Density if sw_mass_property is not None else 0
+        else:
+            click.echo(f"Could not evaluate {sw_comp_name}")
 
         # Create an new entity in the general dict
         dict_of_comp[sw_comp_name] = {


### PR DESCRIPTION
# Description

- Check the document is not None before getting its mass properties for the stat module
- Check if the part is suppressed before including it in the stat module

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested on assembly with suppressed parts
